### PR TITLE
schema builder supports set tags

### DIFF
--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -104,7 +104,7 @@ module BreadcrumbsOnRails
     # pass the option <tt>:builder => BreadcrumbsOnRails::Breadcrumbs::SchemaDotOrgBuilder</tt> to use this.
     class SchemaDotOrgBuilder < Builder
       def render
-        @context.content_tag(@options[:tag] || @options[:root_tag],
+        @context.content_tag(@options[:tag] || @options[:root_tag] || :div,
           { :itemscope => :itemscope, :itemtype => "http://schema.org/BreadcrumbList" }) do
 
           @elements.each_with_index.map do |element, index|
@@ -124,7 +124,7 @@ module BreadcrumbsOnRails
         end
 
         children_tag = @context.content_tag(
-          @options[:tag] || @options[:children_tag],
+          @options[:tag] || @options[:children_tag] || :div,
           [content, meta_tag].join.html_safe,
           {
             itemscope: :itemscope,

--- a/lib/breadcrumbs_on_rails/breadcrumbs.rb
+++ b/lib/breadcrumbs_on_rails/breadcrumbs.rb
@@ -33,7 +33,7 @@ module BreadcrumbsOnRails
       # Renders Elements and returns the Breadcrumb navigation for the view.
       #
       # @abstract You must implement this method in your custom Builder.
-      # 
+      #
       # @return [String] the result of the breadcrumb rendering
       def render
         raise NotImplementedError
@@ -100,11 +100,13 @@ module BreadcrumbsOnRails
     # SchemaDotOrgBuilder is another implementation which will render breadcrumbs as per schema.org standard.
     # ref: https://developers.google.com/search/docs/data-types/breadcrumb#year-genre%20example
     #
-    # :tag won't be applicable for this builder. To use this builder instead of the default,
+    # this builder supports :tag, :root_tag, :children_tag. To use this builder instead of the default,
     # pass the option <tt>:builder => BreadcrumbsOnRails::Breadcrumbs::SchemaDotOrgBuilder</tt> to use this.
     class SchemaDotOrgBuilder < Builder
       def render
-        @context.content_tag(:div, { :itemscope => :itemscope, :itemtype => "http://schema.org/BreadcrumbList" }) do
+        @context.content_tag(@options[:tag] || @options[:root_tag],
+          { :itemscope => :itemscope, :itemtype => "http://schema.org/BreadcrumbList" }) do
+
           @elements.each_with_index.map do |element, index|
             render_element(element, index)
           end.join(@options[:separator] || " &raquo; ").html_safe
@@ -121,10 +123,16 @@ module BreadcrumbsOnRails
           content = @context.link_to_unless_current(content_wrap_tag, compute_path(element), element.options)
         end
 
-        div_tag = @context.content_tag(:div, [content, meta_tag].join.html_safe, {
-          :itemscope => :itemscope, :itemtype => 'http://schema.org/ListItem', :itemprop => :itemListElement
-        })
-        ERB::Util.h(div_tag)
+        children_tag = @context.content_tag(
+          @options[:tag] || @options[:children_tag],
+          [content, meta_tag].join.html_safe,
+          {
+            itemscope: :itemscope,
+            itemtype:  'http://schema.org/ListItem',
+            itemprop:  :itemListElement
+          }
+        )
+        ERB::Util.h(children_tag)
       end
     end
 


### PR DESCRIPTION
example:     
```
  = render_breadcrumbs(builder: BreadcrumbsOnRails::Breadcrumbs::SchemaDotOrgBuilder, tag: :span)
```
or

```
  = render_breadcrumbs(builder: BreadcrumbsOnRails::Breadcrumbs::SchemaDotOrgBuilder, root_tag: :ol, children_tag: :li)
```